### PR TITLE
Bump plotly.js-dist v1.55.1

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^1.54.5"
+    "plotly.js-dist": "^1.55.1"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
bump `plotly.js-dist` version at 1.55.1

@captainsafia 

cc: @nicolaskruchten 