### PR TITLE
Bump plotly.js-dist version at 1.55.2

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^1.55.1"
+    "plotly.js-dist": "^1.55.2"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
bump `plotly.js-dist` version at 1.55.2 including some fixes:
https://github.com/plotly/plotly.js/releases/tag/v1.55.2

@captainsafia 

cc: @nicolaskruchten 