### PR TITLE
bump plotly.js-dist v1.57.1

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^1.57.0"
+    "plotly.js-dist": "^1.57.1"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
Bump plotly.js-dist version at 1.57.1 including fixes
https://github.com/plotly/plotly.js/releases/tag/v1.57.1

@captainsafia

cc: @nicolaskruchten