### PR TITLE
Bump plotly.js-dist version to v1.58.0

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^1.57.1"
+    "plotly.js-dist": "^1.58.0"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
Bump plotly.js-dist version at 1.58.0 including fixes & new features!
https://github.com/plotly/plotly.js/releases/tag/v1.58.0

@captainsafia

cc: @nicolaskruchten