### PR TITLE
Bump plotly.js-dist v1.58.3

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^1.58.2"
+    "plotly.js-dist": "^1.58.3"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
Bump `plotly.js-dist` version at 1.58.3 including:
https://github.com/plotly/plotly.js/releases/tag/v1.58.3

@captainsafia 

cc: @nicolaskruchten 