### PR TITLE
bump plotly.js-dist v1.58.4

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^1.58.3"
+    "plotly.js-dist": "^1.58.4"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
Fixes `preserveDrawingBuffer` WebGL config for displaying transparent 3d scenes 
on Apple devices running latest Safari versions (v13 and higher)

https://github.com/plotly/plotly.js/releases/tag/v1.58.4

@captainsafia

cc: @nicolaskruchten