### PR TITLE
Small fix to CSS property name

### DIFF
--- a/packages/outputs/src/components/output.tsx
+++ b/packages/outputs/src/components/output.tsx
@@ -34,7 +34,7 @@ interface ReactErrorInfo {
 }
 
 const ErrorFallbackDiv = styled.div`
-  backgroundcolor: ghostwhite;
+  background-color: ghostwhite;
   color: black;
   font-weight: 600;
   display: block;

--- a/packages/outputs/src/components/rich-media.tsx
+++ b/packages/outputs/src/components/rich-media.tsx
@@ -54,7 +54,7 @@ interface State {
 }
 
 const ErrorFallbackDiv = styled.div`
-  backgroundcolor: ghostwhite;
+  background-color: ghostwhite;
   color: black;
   font-weight: 600;
   display: block;


### PR DESCRIPTION
`backgroundcolor` -> `background-color`

Fixes contrast issue for ErrorFallbackDiv when using dark theme

This is what it looked like with dark theme:
![image](https://user-images.githubusercontent.com/1588988/106984271-1a204600-671c-11eb-853e-c55d7222ed33.png)

After changing `backgroundcolor` to `background-color` in the Chrome style inspector:
![image](https://user-images.githubusercontent.com/1588988/106984358-44720380-671c-11eb-8ad0-f26f7a316e6b.png)
