### PR TITLE
Major plotly.js bump to v2.2.1

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^1.58.4"
+    "plotly.js-dist": "^2.2.1"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
Bump `plotly.js-dist` version at 2.2.1 including fixes, new features and breaking changes!
https://github.com/plotly/plotly.js/releases/tag/v2.0.0
https://github.com/plotly/plotly.js/releases/tag/v2.1.0
https://github.com/plotly/plotly.js/releases/tag/v2.2.0
https://github.com/plotly/plotly.js/releases/tag/v2.2.1

@captainsafia 

cc: @nicolaskruchten 