### PR TITLE
chore: bump plotly.js to v2.4.2

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^2.2.1"
+    "plotly.js-dist": "^2.4.1"
   },
   "peerDependencies": {
     "react": "^16.3.2"

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^2.4.1"
+    "plotly.js-dist": "^2.4.2"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
Bump `plotly.js-dist` version at 2.4.1 including fixes, new features
https://github.com/plotly/plotly.js/releases/tag/v2.3.0
https://github.com/plotly/plotly.js/releases/tag/v2.3.1
https://github.com/plotly/plotly.js/releases/tag/v2.4.0
https://github.com/plotly/plotly.js/releases/tag/v2.4.1
https://github.com/plotly/plotly.js/releases/tag/v2.4.2

@captainsafia 

cc: @nicolaskruchten 