### PR TITLE
fix: import phosphor.css to fix build error

### DIFF
--- a/packages/jupyter-widgets/src/renderer/backbone-wrapper.tsx
+++ b/packages/jupyter-widgets/src/renderer/backbone-wrapper.tsx
@@ -9,7 +9,7 @@ import { WidgetManager } from "../manager/widget-manager";
 import "@jupyter-widgets/base/css/index.css";
 import "@jupyter-widgets/controls/css/labvariables.css";
 import "@jupyter-widgets/controls/css/materialcolors.css";
-import "@jupyter-widgets/controls/css/lumino.css";
+import "@jupyter-widgets/controls/css/phosphor.css";
 import "@jupyter-widgets/controls/css/widgets-base.css";
 import "@jupyter-widgets/controls/css/widgets.css";
 


### PR DESCRIPTION
Import the phosphor.css instead of the lumino.css to fix the build error.