### PR TITLE
Removed updateCellStatus from widgets

### DIFF
--- a/packages/jupyter-widgets/__tests__/manager/manager.spec.ts
+++ b/packages/jupyter-widgets/__tests__/manager/manager.spec.ts
@@ -18,7 +18,6 @@ const mockRequireJS = jest.fn((modules, ready, errCB) => ready(mockFooModule));
 const mockManagerActions: ManagerActions["actions"] = {
   appendOutput: jest.fn(),
   clearOutput: jest.fn(),
-  updateCellStatus: jest.fn(),
   promptInputRequest: jest.fn()
 };
 

--- a/packages/jupyter-widgets/src/manager/index.tsx
+++ b/packages/jupyter-widgets/src/manager/index.tsx
@@ -8,8 +8,7 @@ import {
   KernelNotStartedProps,
   LocalKernelProps,
   RemoteKernelProps,
-  ContentRef,
-  KernelStatus
+  ContentRef
 } from "@nteract/core";
 import { CellId } from "@nteract/commutable";
 import { WidgetModel } from "@jupyter-widgets/base";
@@ -27,7 +26,6 @@ export interface ManagerActions {
   actions: {
     appendOutput: (output: any) => void;
     clearOutput: () => void;
-    updateCellStatus: (status: KernelStatus) => void;
     promptInputRequest: (prompt: string, password: boolean) => void;
   };
 }
@@ -112,14 +110,6 @@ const mapDispatchToProps = (dispatch: any, props: OwnProps): ManagerActions => {
           actions.clearOutputs({
             id: props.id,
             contentRef: props.contentRef
-          })
-        ),
-      updateCellStatus: (status: KernelStatus) =>
-        dispatch(
-          actions.updateCellStatus({
-            id: props.id,
-            contentRef: props.contentRef,
-            status
           })
         ),
       promptInputRequest: (prompt: string, password: boolean) =>

--- a/packages/jupyter-widgets/src/manager/widget-manager.ts
+++ b/packages/jupyter-widgets/src/manager/widget-manager.ts
@@ -197,8 +197,13 @@ export class WidgetManager extends base.ManagerBase<DOMWidgetView> {
             output_type: reply.header.msg_type
           }),
         clear_output: (reply: JupyterMessage) => this.actions.clearOutput(),
-        status: (reply: JupyterMessage) =>
-          this.actions.updateCellStatus(reply.content.execution_state)
+        status: (reply: JupyterMessage) => {
+          /**
+           * Currently, we don't do anything with status messages. Previously,
+           * we updated the cell status, but we removed it because it was confusing
+           * to users and had bugs related to widgets updating the wrong cell's status
+           */
+        }
       },
       input: (reply: JupyterMessage) =>
         this.actions.promptInputRequest(


### PR DESCRIPTION
This PR removed the updateCellStatus call from jupyter-widgets, meaning that they no longer set the cell status as busy when communicating with the kernel

See issue #76 