### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/jupyter-widgets/package.json
+++ b/packages/jupyter-widgets/package.json
@@ -3,12 +3,12 @@
   "version": "4.4.14",
   "description": "Transform for rendering Jupyter-JS-Widgets in output areas.",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/nteract/outputs.git",
     "directory": "packages/jupyter-widgets"
   },
-  "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {
     "test": "jest .",

--- a/packages/jupyter-widgets/package.json
+++ b/packages/jupyter-widgets/package.json
@@ -3,6 +3,11 @@
   "version": "4.4.14",
   "description": "Transform for rendering Jupyter-JS-Widgets in output areas.",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/outputs.git",
+    "directory": "packages/jupyter-widgets"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/outputs/package.json
+++ b/packages/outputs/package.json
@@ -3,6 +3,11 @@
   "version": "3.0.11",
   "description": "components for rendering outputs",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/outputs.git",
+    "directory": "packages/outputs"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.ts",
   "scripts": {

--- a/packages/transform-geojson/package.json
+++ b/packages/transform-geojson/package.json
@@ -3,6 +3,11 @@
   "version": "5.1.13",
   "description": "GeoJSON Transform",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/outputs.git",
+    "directory": "packages/transform-geojson"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.tsx",
   "scripts": {

--- a/packages/transform-model-debug/package.json
+++ b/packages/transform-model-debug/package.json
@@ -3,6 +3,11 @@
   "version": "5.0.1",
   "description": "Transform for debug usage with nteract models",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/outputs.git",
+    "directory": "packages/transform-model-debug"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.tsx",
   "scripts": {

--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -3,6 +3,11 @@
   "version": "6.1.10",
   "description": "Plotly Transform",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/outputs.git",
+    "directory": "packages/transform-plotly"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.tsx",
   "scripts": {

--- a/packages/transform-vdom/package.json
+++ b/packages/transform-vdom/package.json
@@ -3,6 +3,11 @@
   "version": "4.0.15",
   "description": "VDOM Transform for jupyter outputs",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/outputs.git",
+    "directory": "packages/transform-vdom"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.tsx",
   "scripts": {

--- a/packages/transform-vega/package.json
+++ b/packages/transform-vega/package.json
@@ -3,6 +3,11 @@
   "version": "7.0.10",
   "description": "Vega Transform",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/outputs.git",
+    "directory": "packages/transform-vega"
+  },
   "types": "lib/index.d.ts",
   "nteractDesktop": "src/index.tsx",
   "scripts": {


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @nteract/outputs
* @nteract/jupyter-widgets
* @nteract/transform-plotly
* @nteract/transform-geojson
* @nteract/transform-vdom
* @nteract/transform-vega
* @nteract/transform-model-debug