### PR TITLE
Bump plotly.js to v2.6.3

### DIFF
--- a/packages/transform-plotly/package.json
+++ b/packages/transform-plotly/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
-    "plotly.js-dist": "^2.4.2"
+    "plotly.js-dist": "^2.6.3"
   },
   "peerDependencies": {
     "react": "^16.3.2"


### PR DESCRIPTION
Bump `plotly.js-dist` version at 2.6.3 including fixes, new features
https://github.com/plotly/plotly.js/releases/tag/v2.5.0
https://github.com/plotly/plotly.js/releases/tag/v2.5.1
https://github.com/plotly/plotly.js/releases/tag/v2.6.0
https://github.com/plotly/plotly.js/releases/tag/v2.6.1
https://github.com/plotly/plotly.js/releases/tag/v2.6.2
https://github.com/plotly/plotly.js/releases/tag/v2.6.3

@captainsafia 

cc: @nicolaskruchten 