### PR TITLE
Making nteract outputs more configurable for ansi outputs

### DIFF
--- a/packages/outputs/__tests__/output.spec.tsx
+++ b/packages/outputs/__tests__/output.spec.tsx
@@ -1,6 +1,6 @@
 import { mount, shallow } from "enzyme";
 import * as React from "react";
-
+import Ansi from "ansi-to-react";
 import { createImmutableOutput, ImmutableOutput } from "@nteract/commutable";
 
 import {
@@ -113,6 +113,46 @@ describe("Output", () => {
   });
 });
 
+describe("Output ansi options", () => {
+  it("stream data", () => {
+    const output = createImmutableOutput({
+      output_type: "stream",
+      name: "stdout",
+      text: "hey"
+    });
+
+    const component = mount(
+      <Output output={output}>
+        <StreamText linkify={false} useClasses={true} />
+      </Output>
+    );
+
+    expect(component.find("StreamText")).not.toBeNull();
+    expect(component.find(Ansi).prop("linkify")).toBe(false);
+    expect(component.find(Ansi).prop("useClasses")).toBe(true);
+  });
+
+  it("error data", () => {
+    const output = createImmutableOutput({
+      output_type: "error",
+      traceback: ["Yikes, Will is in the upsidedown again!"],
+      ename: "NameError",
+      evalue: "Yikes!"
+    });
+
+    const component = mount(
+      <Output output={output}>
+        <KernelOutputError linkify={true} useClasses={true} />
+      </Output>
+    );
+
+    expect(component.find("KernelOutputError")).not.toBeNull();
+    expect(component.find(Ansi).prop("linkify")).toBe(true);
+    expect(component.find(Ansi).prop("useClasses")).toBe(true);
+  });
+});
+
+
 describe("Full Outputs usage", () => {
   const testOutput = createImmutableOutput({
     output_type: "display_data",
@@ -219,4 +259,5 @@ describe("Output with an array of output_types", () => {
     expect(wrapperExecuteResult.find(Media.HTML).exists()).toEqual(true);
     expect(wrapperOtherOutput.html()).toEqual("");
   });
+  
 });

--- a/packages/outputs/src/components/kernel-output-error.tsx
+++ b/packages/outputs/src/components/kernel-output-error.tsx
@@ -8,6 +8,8 @@ interface Props {
   className?: string;
   output: ImmutableErrorOutput;
   output_type: "error";
+  linkify?: boolean;
+  useClasses?: boolean;
 }
 
 const PlainKernelOutputError = (props: Partial<Props>) => {
@@ -33,7 +35,7 @@ const PlainKernelOutputError = (props: Partial<Props>) => {
   }
 
   return (
-    <Ansi className={props.className} linkify={false}>
+    <Ansi className={props.className} linkify={props.linkify ?? false} useClasses={props.useClasses ?? false }>
       {kernelOutputError.join("\n")}
     </Ansi>
   );

--- a/packages/outputs/src/components/stream-text.tsx
+++ b/packages/outputs/src/components/stream-text.tsx
@@ -5,6 +5,8 @@ import * as React from "react";
 interface Props {
   output_type: "stream";
   output: ImmutableStreamOutput;
+  linkify?: boolean;
+  useClasses?: boolean;
 }
 
 export class StreamText extends React.PureComponent<Props> {
@@ -14,14 +16,14 @@ export class StreamText extends React.PureComponent<Props> {
   };
 
   render() {
-    const { output } = this.props;
+    const { output, linkify, useClasses } = this.props;
     if (!output) {
       return null;
     }
     const { text, name } = output;
 
     return (
-      <Ansi linkify className={`nteract-display-area-${name}`}>
+      <Ansi linkify={linkify ?? true} className={`nteract-display-area-${name}`} useClasses={useClasses}>
         {text}
       </Ansi>
     );


### PR DESCRIPTION
RFC: https://github.com/nteract/outputs/issues/99

Ansi props now can be configured from the nteract output object (Stream-text or kernel-output-error) so that these options can now be configured by nteract consumers. 